### PR TITLE
Build distribution with uv instead of hatch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
       - name: Build package
-        run: pipx install hatch && hatch build
+        run: uv build
       - name: Publish sphinx-helm
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Just playing around with using `uv` to build the distribution instead of `hatch`. It will still use the `hatchling` build backend, the only change is the CLI tool used to launch the build.