### PR TITLE
Fix bad package name in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add the extension to your Sphinx config.
 ```python
 # conf.py
 
-extensions = ['sphinx-helm.ext']
+extensions = ['sphinx_helm.ext']
 ```
 
 Use the directive to generate documentation for your helm chart.

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ Creating hello-world
 Enable the plugin in your Sphinx `conf.py` file:
 
 ```python
-extensions = ['sphinx-helm.ext']
+extensions = ['sphinx_helm.ext']
 ```
 
 Now you can use the `helm` directive wherever you wish in your documentation.


### PR DESCRIPTION
Import name is `sphinx_helm` but package name is `sphinx-helm`. Fixing up config examples to use import name correctly. 